### PR TITLE
chore(release): 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trep"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Bump crate version to 0.1.1 for:

- Refactor: extract record file path logic to util
- Tests: add unit tests for duration parsing, writers, and util path building
- Docs: README and CONTRIBUTING updates
- CI: fmt/clippy/build/test workflow

Local verification before PR:
- cargo fmt — ok
- cargo clippy -D warnings — ok
- cargo build — ok
- cargo test — 4 passed

After merge, I will tag v0.1.1 and create a GitHub release.