### PR TITLE
chore: automate version bumps with Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,26 @@
+name: Release Please
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      release-as:
+        description: "Explicit version to release (e.g., 0.2.0). Optional."
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Release Please
+        uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: rust
+          package-name: trep
+          # Optional manual override via workflow_dispatch
+          release-as: ${{ github.event.inputs.release-as }}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,13 @@ CI
 --
 GitHub Actions (`.github/workflows/ci.yml`) runs the same checks on pushes to `main` and on pull requests.
 
+Releases
+--------
+This repo uses Release Please to automate version bumps and GitHub releases.
+
+- Conventional commits drive the next version:
+  - `feat(scope): ...` → minor version
+  - `fix(scope): ...` → patch version
+  - `feat!` or `BREAKING CHANGE:` in body → major version
+- A "Release PR" is opened automatically on pushes to `main`; merging it creates the tag and GitHub release.
+- Manual trigger: run the "Release Please" workflow with the optional `release-as` input to force a version (e.g., `0.2.0`).


### PR DESCRIPTION
## Summary
Automate version bumps and GitHub releases using Release Please.

## Changes
- Add Release Please workflow at `.github/workflows/release-please.yml` configured for Rust (`trep`).
- Update `CONTRIBUTING.md` with a Releases section (conventional commits, Release PR flow, manual trigger).

## Testing
- [x] Local pre-push checks passed (`cargo fmt`, `clippy -D warnings`, `build`, `test`).
- [x] Branch pushed; GitHub recognizes the workflow file.
- [x] Manual workflow run (dry-run) optional after merge to `main`.

## Checklist
- [x] Updated README/docs if needed
- [x] No unrelated changes
