### PR TITLE
chore(release): bump version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trep"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
Manual version bump to 0.1.2 for the `trep` crate.

## Changes
- Update Cargo.toml: `version = "0.1.2"`

## Testing
- [x] cargo fmt (check)
- [x] cargo clippy (deny warnings)
- [x] cargo build (all targets)
- [x] cargo test (all pass)

## Checklist
- [x] No unrelated changes
- [ ] Tag `v0.1.2` after merge (optional)
