### PR TITLE
Add integration tests for temporary HOME

### DIFF
--- a/tests/temp_home.rs
+++ b/tests/temp_home.rs
@@ -1,0 +1,51 @@
+use std::fs;
+use std::process::Command;
+
+use chrono::Local;
+use tempfile::TempDir;
+
+#[test]
+fn csv_output_and_lock_in_temp_home() {
+    let home = TempDir::new().unwrap();
+    let name = "demo";
+    let status = Command::new(env!("CARGO_BIN_EXE_trep"))
+        .args([
+            "run", "--as", name, "--format", "csv", "--", "echo", "hello",
+        ])
+        .env("HOME", home.path())
+        .status()
+        .expect("failed to run trep");
+    assert!(status.success());
+
+    let date = Local::now().format("%Y-%m-%d").to_string();
+    let base = home.path().join(".tiny-reporter").join(name);
+    let csv_path = base.join(format!("{date}.csv"));
+    let lock_path = base.join(format!("{name}.lock"));
+    assert!(csv_path.exists(), "missing csv file");
+    assert!(lock_path.exists(), "missing lock file");
+
+    let contents = fs::read_to_string(csv_path).unwrap();
+    assert!(contents.contains("hello"));
+}
+
+#[test]
+fn jsonl_output_in_temp_home() {
+    let home = TempDir::new().unwrap();
+    let name = "demo";
+    let status = Command::new(env!("CARGO_BIN_EXE_trep"))
+        .args(["run", "--as", name, "--format", "jsonl", "--", "echo", "hi"])
+        .env("HOME", home.path())
+        .status()
+        .expect("failed to run trep");
+    assert!(status.success());
+
+    let date = Local::now().format("%Y-%m-%d").to_string();
+    let base = home.path().join(".tiny-reporter").join(name);
+    let jsonl_path = base.join(format!("{date}.jsonl"));
+    let lock_path = base.join(format!("{name}.lock"));
+    assert!(jsonl_path.exists(), "missing jsonl file");
+    assert!(lock_path.exists(), "missing lock file");
+
+    let contents = fs::read_to_string(jsonl_path).unwrap();
+    assert!(contents.contains("hi"));
+}


### PR DESCRIPTION
## Summary
- add end-to-end tests that run trep with HOME pointed to a temp dir
- verify CSV/JSONL record files and lock file are created under date-rotated paths

## Changes
- add integration tests covering csv/jsonl outputs and lock file behavior when HOME is overridden

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test`
- [x] `HOME=$(mktemp -d) cargo run -- run --as demo -- echo hi`

## Checklist
- [ ] Updated README/docs if needed
- [x] Added tests (if applicable)
- [x] No unrelated changes

Closes #24.

------
https://chatgpt.com/codex/tasks/task_e_689b82665f608333b62f48de1d1fcc4b